### PR TITLE
fakesmtp: актуализировал маппинг портов

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.idea
 /.env
+/docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,9 +184,13 @@ services:
         aliases:
           - fakesmtp
     ports:
-      - ${BX_SMTP_WEB_PORT}:8080
-      - ${BX_SMTP_REST_PORT}:8081
-      - ${BX_SMTP_PORT}:8025
+      - ${BX_SMTP_WEB_PORT}:5080
+      - ${BX_SMTP_REST_PORT}:5081
+      - ${BX_SMTP_PORT}:5025
+    environment:
+      - SERVER_PORT=5080
+      - MANAGEMENT_SERVER_PORT=5081
+      - FAKESMTP_PORT=5025
 
 networks:
   bx:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,9 +184,9 @@ services:
         aliases:
           - fakesmtp
     ports:
-      - ${BX_SMTP_WEB_PORT}:5080
-      - ${BX_SMTP_REST_PORT}:5081
-      - ${BX_SMTP_PORT}:5025
+      - ${BX_SMTP_WEB_PORT}:8080
+      - ${BX_SMTP_REST_PORT}:8081
+      - ${BX_SMTP_PORT}:8025
 
 networks:
   bx:


### PR DESCRIPTION
У fake smtp в апстриме поменялись порты по умолчанию, после пересборки отвалился smtp. Добавил параметры со старыми портами.