### PR TITLE
Изменение маппинга портов FakeSMTP и конфигурация msmtp с учетом изменившихся портов в контейнере

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -184,9 +184,9 @@ services:
         aliases:
           - fakesmtp
     ports:
-      - ${BX_SMTP_WEB_PORT}:5080
-      - ${BX_SMTP_REST_PORT}:5081
-      - ${BX_SMTP_PORT}:5025
+      - ${BX_SMTP_WEB_PORT}:8080
+      - ${BX_SMTP_REST_PORT}:8081
+      - ${BX_SMTP_PORT}:8025
 
 networks:
   bx:

--- a/php8/Dockerfile
+++ b/php8/Dockerfile
@@ -82,7 +82,6 @@ RUN sed -i "$ a xdebug.client_host="${BX_XDEBUG_IP} /usr/local/etc/php/conf.d/xd
     && sed -i "$ a xdebug.client_port="${BX_XDEBUG_PORT} /usr/local/etc/php/conf.d/xdebug.ini \
     && sed -i "$ a default_charset="${BX_DEFAULT_CHARSET} /usr/local/etc/php/conf.d/php.ini \
     && sed -i "$ a mbstring.internal_encoding="${BX_DEFAULT_CHARSET} /usr/local/etc/php/conf.d/mbstring.ini \
-    && sed -i "$ a port "${BX_SMTP_PORT} /usr/local/etc/msmtp/msmtp.conf \
     && sed -i "$ a from "${BX_SMTP_FROM} /usr/local/etc/msmtp/msmtp.conf
 
  # PHPUnit

--- a/php8/msmtp/msmtp.conf
+++ b/php8/msmtp/msmtp.conf
@@ -3,3 +3,4 @@ logfile /dev/null
 host fakesmtp
 auth off
 tls off
+port 8025

--- a/php81/Dockerfile
+++ b/php81/Dockerfile
@@ -82,7 +82,6 @@ RUN sed -i "$ a xdebug.client_host="${BX_XDEBUG_IP} /usr/local/etc/php/conf.d/xd
     && sed -i "$ a xdebug.client_port="${BX_XDEBUG_PORT} /usr/local/etc/php/conf.d/xdebug.ini \
     && sed -i "$ a default_charset="${BX_DEFAULT_CHARSET} /usr/local/etc/php/conf.d/php.ini \
     && sed -i "$ a mbstring.internal_encoding="${BX_DEFAULT_CHARSET} /usr/local/etc/php/conf.d/mbstring.ini \
-    && sed -i "$ a port "${BX_SMTP_PORT} /usr/local/etc/msmtp/msmtp.conf \
     && sed -i "$ a from "${BX_SMTP_FROM} /usr/local/etc/msmtp/msmtp.conf
 
  # PHPUnit

--- a/php81/msmtp/msmtp.conf
+++ b/php81/msmtp/msmtp.conf
@@ -3,3 +3,4 @@ logfile /dev/null
 host fakesmtp
 auth off
 tls off
+port 8025

--- a/php82/Dockerfile
+++ b/php82/Dockerfile
@@ -82,7 +82,6 @@ RUN sed -i "$ a xdebug.client_host="${BX_XDEBUG_IP} /usr/local/etc/php/conf.d/xd
     && sed -i "$ a xdebug.client_port="${BX_XDEBUG_PORT} /usr/local/etc/php/conf.d/xdebug.ini \
     && sed -i "$ a default_charset="${BX_DEFAULT_CHARSET} /usr/local/etc/php/conf.d/php.ini \
     && sed -i "$ a mbstring.internal_encoding="${BX_DEFAULT_CHARSET} /usr/local/etc/php/conf.d/mbstring.ini \
-    && sed -i "$ a port "${BX_SMTP_PORT} /usr/local/etc/msmtp/msmtp.conf \
     && sed -i "$ a from "${BX_SMTP_FROM} /usr/local/etc/msmtp/msmtp.conf
 
  # PHPUnit

--- a/php82/msmtp/msmtp.conf
+++ b/php82/msmtp/msmtp.conf
@@ -3,3 +3,4 @@ logfile /dev/null
 host fakesmtp
 auth off
 tls off
+port 8025


### PR DESCRIPTION
FakeSMTP сейчас использует порты 8080,8081,8025. Фикс адаптирует к этому конфигурацию маппинга и сервиса msmtp (было настроено на 50*)